### PR TITLE
virtio-drivers: v0.1.204-1

### DIFF
--- a/virtio-drivers/tools/chocolateyInstall.ps1
+++ b/virtio-drivers/tools/chocolateyInstall.ps1
@@ -3,9 +3,9 @@ $isoPath = Join-Path $pkgDir virtio.iso
 $downloadArgs = @{
 	packageName = $Env:ChocolateyPackageName
 	fileFullPath = $isoPath
-	url = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.196-1/virtio-win.iso'
+	url = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.204-1/virtio-win.iso'
 	checksumType = 'sha512'
-	checksum = '0438380e5c9bc680104268a826c47f817b086522a94d3b25cce363a6cd2026240ae52e25eff19aa450f3aad83b99485cccacbe7f8e697bc18a309f5b1d680b39'
+	checksum = 'dd28dd18e4189a950f62cb9c5553f79c98daa1dbf9d945c30f1cfc6ded9861f57d7cb692c54af20ebe58eadf0a987c3dcf3cd3c2ad6fff700ca1d149923aacb3'
 }
 Get-ChocolateyWebFile @downloadArgs
 $extractPath = Join-Path $pkgDir virtio

--- a/virtio-drivers/virtio-drivers.nuspec
+++ b/virtio-drivers/virtio-drivers.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>virtio-drivers</id>
-    <version>0.1.196.100</version>
+    <version>0.1.204.100</version>
     <title>virtIO drivers</title>
     <authors>Red Hat, Google, Virtuozzo, IBM</authors>
     <owners>DDoSolitary</owners>


### PR DESCRIPTION
This PR bumps virtio-drivers to v0.1.204-1, including an updated URL and checksum.

I'm not sure how best to test the package.  Feel free to consider this a request more than a thoroughly tested proposal.

Cheers,
Kevin